### PR TITLE
updated time parsing process

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -756,7 +756,7 @@ module Signet
       # @param [String,Fixnum,Time] new_issued_at
       #    The access token issuance time.
       def issued_at=(new_issued_at)
-        @issued_at = normalize_timestamp(new_issued_at)
+        @issued_at = Time.at(new_issued_at)
       end
 
       ##


### PR DESCRIPTION
**WHY?**

While trying to use 

```
gem 'google-api-client', '< 0.9'
```

against sample code in [google-api-ruby-client-samples-calender](https://github.com/google/google-api-ruby-client-samples/blob/master/calendar/calendar.rb)

After authentication is successful, on second attempt when the oauth2 data is being read from the file storage, signet fails to read the timestamp, throwing following error:

```
signet-0.7.2/lib/signet/oauth_2/client.rb:1188:in `normalize_timestamp': Invalid time value 1456726281 (RuntimeError)
```

**What?**
using a function that can parse timestamp
